### PR TITLE
名前を追加してブラウザにも名前と送信した結果を返すようにした

### DIFF
--- a/form.html
+++ b/form.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="ja">
-<head>
-	<meta charset="UTF-8">
-	<title>アンケート</title>
-</head>
+  <head>
+    <meta charset="UTF-8" />
+    <title>アンケート</title>
+  </head>
 
-<body>
-	<h1>どちらが食べたいですか？</h1>
-	<form method="post" action="/enquetes/yaki-shabu">
-		<input type="radio" name="yaki-shabu" value="焼き肉" /> 焼き肉
-		<input type="radio" name="yaki-shabu" value="しゃぶしゃぶ" /> しゃぶしゃぶ
-		<button type="submit">投稿</button>
-	</form>
-</body>
-
+  <body>
+    <h1>どちらが食べたいですか？</h1>
+    <form method="post" action="/enquetes/yaki-shabu">
+      名前: <input type="text" name="name" />
+      <input type="radio" name="yaki-shabu" value="焼き肉" /> 焼き肉
+      <input type="radio" name="yaki-shabu" value="しゃぶしゃぶ" /> しゃぶしゃぶ
+      <button type="submit">投稿</button>
+    </form>
+  </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const http = require('http');
+
 const server = http
   .createServer((req, res) => {
     const now = new Date();
@@ -21,14 +22,24 @@ const server = http
             rawData = rawData + chunk;
           })
           .on('end', () => {
+            const qs = require('querystring');
             const decoded = decodeURIComponent(rawData);
             console.info('[' + now + '] 投稿: ' + decoded);
+            const answer = qs.parse(rawData);//parseの中身はデコードしてもしてなくても結果は変わらないようだ
+            const a = answer['name'];
+            const b = answer['yaki-shabu'];
+            console.log(decoded);//name=なまえ&yaki-shabu=しゃぶしゃぶ　　デコードした状態
+            console.log(answer);//[Object: null prototype] { name: 'なまえ', 'yaki-shabu': 'しゃぶしゃぶ' }　　パースした状態
+            console.log(rawData);//name=%E3%81%AA%E3%81%BE%E3%81%88&yaki-shabu=%E3%81%97%E3%82%83%E3%81%B6%E3%81%97%E3%82%83%E3%81%B6　そのままのデータ
             res.write(
               '<!DOCTYPE html><html lang="ja"><body><h1>' +
-                decoded +
-                'が投稿されました</h1></body></html>'
+                b + 'が' + a +'さんによって投稿されました</h1></body></html>'
             );
             res.end();
+
+      
+
+
           });
         break;
       default:


### PR DESCRIPTION
parseが文字を分解してオブジェクトを作ってくれるということがわかった。（）に渡す値はデコードはしてもしなくてもどっちでもオブジェクトの中身は文字化けしないようになるようだ